### PR TITLE
Memory reduction surgery

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Comic Book Reader
 * X Make workers recycle, so they can free all the memory used for the archive and entries
 * X Make the workers write into indexedDB instead of creating Object URLs
 * X Fix issue with Object URLs getting corrupted
-* Instead of storing all pages in Object URLs when they are not showing, store them in indexedDB.
+* X Instead of storing all pages in Object URLs when they are not showing, store them in indexedDB.
 	Only use Object URLs for the loaded images.
 * X Move any File to Array Buffer conversions into the workers if possible.
 

--- a/README.md
+++ b/README.md
@@ -13,8 +13,7 @@ Comic Book Reader
 * X Fix issue with Object URLs getting corrupted
 * Instead of storing all pages in Object URLs when they are not showing, store them in indexedDB.
 	Only use Object URLs for the loaded images.
-* After images are created for thumb nails (a big and small for each nail), send them to a
-	worker (negative zone) using transferable objects. Then kill the worker to free the memory.
+* X Move any File to Array Buffer conversions into the workers if possible.
 
 # Bugs:
 * Archives with no images will crash when loading

--- a/README.md
+++ b/README.md
@@ -7,6 +7,15 @@ Comic Book Reader
 * Works when offline
 * Regularly tested in Firefox, Chrome, and Internet Explorer
 
+# Memory Reduction Surgery
+* X Make workers recycle, so they can free all the memory used for the archive and entries
+* X Make the workers write into indexedDB instead of creating Object URLs
+* X Fix issue with Object URLs getting corrupted
+* Instead of storing all pages in Object URLs when they are not showing, store them in indexedDB.
+	Only use Object URLs for the loaded images.
+* After images are created for thumb nails (a big and small for each nail), send them to a
+	worker (negative zone) using transferable objects. Then kill the worker to free the memory.
+
 # Bugs:
 * Archives with no images will crash when loading
 * Checking for App Cache updates does not work (firefox only)

--- a/README.md
+++ b/README.md
@@ -7,14 +7,6 @@ Comic Book Reader
 * Works when offline
 * Regularly tested in Firefox, Chrome, and Internet Explorer
 
-# Memory Reduction Surgery
-* X Make workers recycle, so they can free all the memory used for the archive and entries
-* X Make the workers write into indexedDB instead of creating Object URLs
-* X Fix issue with Object URLs getting corrupted
-* X Instead of storing all pages in Object URLs when they are not showing, store them in indexedDB.
-	Only use Object URLs for the loaded images.
-* X Move any File to Array Buffer conversions into the workers if possible.
-
 # Bugs:
 * Archives with no images will crash when loading
 * Checking for App Cache updates does not work (firefox only)

--- a/js/db.js
+++ b/js/db.js
@@ -215,7 +215,7 @@ function getCachedFile(name, file_name, cb) {
 		console.warn(event);
 	};
 	request.onsuccess = function(event) {
-		console.info('????????? Get worked: ' + file_name);
+		console.info('????????? Get worked: ' + name + ', ' + file_name);
 		var blob = event.target.result;
 		cb(blob);
 	};
@@ -240,7 +240,7 @@ function setCachedFile(name, file_name, blob, cb) {
 		cb(false);
 	};
 	request.onsuccess = function(event) {
-		console.info('????????? Put worked: ' + file_name);
+		console.info('????????? Put worked: ' + name + ', ' + file_name);
 		cb(true);
 	};
 }

--- a/js/last_change_date.js
+++ b/js/last_change_date.js
@@ -1,1 +1,1 @@
-function getLastChangeDate() { return "December 24, 2015 - 21:11:53"; }
+function getLastChangeDate() { return "December 27, 2015 - 00:00:33"; }

--- a/js/last_change_date.js
+++ b/js/last_change_date.js
@@ -1,1 +1,1 @@
-function getLastChangeDate() { return "December 27, 2015 - 03:30:50"; }
+function getLastChangeDate() { return "December 27, 2015 - 03:58:30"; }

--- a/js/last_change_date.js
+++ b/js/last_change_date.js
@@ -1,1 +1,1 @@
-function getLastChangeDate() { return "December 23, 2015 - 20:52:06"; }
+function getLastChangeDate() { return "December 24, 2015 - 14:32:53"; }

--- a/js/last_change_date.js
+++ b/js/last_change_date.js
@@ -1,1 +1,1 @@
-function getLastChangeDate() { return "December 27, 2015 - 03:04:01"; }
+function getLastChangeDate() { return "December 27, 2015 - 03:30:50"; }

--- a/js/last_change_date.js
+++ b/js/last_change_date.js
@@ -1,1 +1,1 @@
-function getLastChangeDate() { return "December 27, 2015 - 03:58:30"; }
+function getLastChangeDate() { return "December 27, 2015 - 04:51:41"; }

--- a/js/last_change_date.js
+++ b/js/last_change_date.js
@@ -1,1 +1,1 @@
-function getLastChangeDate() { return "December 24, 2015 - 14:32:53"; }
+function getLastChangeDate() { return "December 24, 2015 - 21:11:53"; }

--- a/js/last_change_date.js
+++ b/js/last_change_date.js
@@ -1,1 +1,1 @@
-function getLastChangeDate() { return "December 27, 2015 - 00:00:33"; }
+function getLastChangeDate() { return "December 27, 2015 - 03:04:01"; }

--- a/js/worker.js
+++ b/js/worker.js
@@ -75,8 +75,6 @@ function onUncompress(archive) {
 		var entry = entries[i];
 		entry.readData(function(data) {
 			var blob = new Blob([data], {type: getFileMimeType(entry.name)});
-			var url = URL.createObjectURL(blob);
-			console.log('>>>>>>>>>>>>>>>>>>> createObjectURL: ' + url);
 
 			setCachedFile('big', entry.name, blob, function(is_success) {
 				if (! is_success) {
@@ -90,9 +88,9 @@ function onUncompress(archive) {
 					var message = {
 						action: 'uncompressed_each',
 						filename: entry.name,
-						url: url,
 						index: i,
-						is_cached: false
+						is_cached: false,
+						is_last: i === entries.length - 1
 					};
 					self.postMessage(message);
 					onEach(i + 1);
@@ -130,10 +128,13 @@ self.addEventListener('message', function(e) {
 				self.postMessage(message);
 			}
 			break;
+		// FIXME: Move this into a function called onLoadFromCache
 		case 'load_from_cache':
 			dbClose();
 			var filename = e.data.filename;
+			var length = 0;
 			var onStart = function(count) {
+				length = count;
 				var message = {
 					action: 'uncompressed_start',
 					count: count
@@ -150,17 +151,14 @@ self.addEventListener('message', function(e) {
 
 			var i = 0;
 			var onEach = function(name, blob) {
-				var url = URL.createObjectURL(blob);
-				console.log('>>>>>>>>>>>>>>>>>>> createObjectURL: ' + url);
 				console.info(name);
-				console.info(url);
 
 				var message = {
 					action: 'uncompressed_each',
 					filename: name,
-					url: url,
 					index: i,
-					is_cached: true
+					is_cached: true,
+					is_last: i === length - 1
 				};
 				self.postMessage(message);
 				i++;
@@ -169,8 +167,11 @@ self.addEventListener('message', function(e) {
 			getAllCachedPages(filename, onStart, onEach, onEnd);
 			break;
 		case 'start':
-			e.data.array_buffer = null;
 			console.info('Worker started ...');
+			break;
+		case 'stop':
+			console.info('Worker stopped ...');
+			self.close();
 			break;
 	}
 }, false);

--- a/js/worker.js
+++ b/js/worker.js
@@ -104,11 +104,20 @@ function onUncompress(archive) {
 self.addEventListener('message', function(e) {
 	console.info(e);
 
+	// If the data posted is a file, monkey patch the action to be uncompress
+	if (e.data instanceof File) {
+		e.data.action = 'uncompress';
+	}
+
 	switch (e.data.action) {
 		case 'uncompress':
 			dbClose();
-			var array_buffer = e.data.array_buffer;
-			var filename = e.data.filename;
+
+			// Convert the file data into an array buffer
+			var reader = new FileReaderSync();
+			var filename = e.data.name;
+			var array_buffer = reader.readAsArrayBuffer(e.data);
+			delete e.data;
 
 			// Open the file as an archive
 			var archive = archiveOpen(filename, array_buffer);
@@ -127,6 +136,7 @@ self.addEventListener('message', function(e) {
 				};
 				self.postMessage(message);
 			}
+
 			break;
 		// FIXME: Move this into a function called onLoadFromCache
 		case 'load_from_cache':

--- a/main.appcache
+++ b/main.appcache
@@ -1,5 +1,5 @@
 CACHE MANIFEST
-# v1 Sun, Dec 27, 2015  3:04:01 AM
+# v1 Sun, Dec 27, 2015  3:30:51 AM
 
 CACHE:
 favicon.ico

--- a/main.appcache
+++ b/main.appcache
@@ -1,5 +1,5 @@
 CACHE MANIFEST
-# v1 Thu, Dec 24, 2015  2:32:53 PM
+# v1 Thu, Dec 24, 2015  9:11:53 PM
 
 CACHE:
 favicon.ico

--- a/main.appcache
+++ b/main.appcache
@@ -1,5 +1,5 @@
 CACHE MANIFEST
-# v1 Sun, Dec 27, 2015  3:58:30 AM
+# v1 Sun, Dec 27, 2015  4:51:42 AM
 
 CACHE:
 favicon.ico

--- a/main.appcache
+++ b/main.appcache
@@ -1,5 +1,5 @@
 CACHE MANIFEST
-# v1 Wed, Dec 23, 2015  8:52:06 PM
+# v1 Thu, Dec 24, 2015  2:32:53 PM
 
 CACHE:
 favicon.ico

--- a/main.appcache
+++ b/main.appcache
@@ -1,5 +1,5 @@
 CACHE MANIFEST
-# v1 Sun, Dec 27, 2015 12:00:34 AM
+# v1 Sun, Dec 27, 2015  3:04:01 AM
 
 CACHE:
 favicon.ico

--- a/main.appcache
+++ b/main.appcache
@@ -1,5 +1,5 @@
 CACHE MANIFEST
-# v1 Thu, Dec 24, 2015  9:11:53 PM
+# v1 Sun, Dec 27, 2015 12:00:34 AM
 
 CACHE:
 favicon.ico

--- a/main.appcache
+++ b/main.appcache
@@ -1,5 +1,5 @@
 CACHE MANIFEST
-# v1 Sun, Dec 27, 2015  3:30:51 AM
+# v1 Sun, Dec 27, 2015  3:58:30 AM
 
 CACHE:
 favicon.ico

--- a/main.js
+++ b/main.js
@@ -1291,10 +1291,6 @@ function startWorker() {
 				$('#loadingProgress').show();
 				break;
 			case 'uncompressed_done':
-				// FIXME: In Chrome, if the worker is terminated, all object URLs die
-//				g_worker.terminate();
-//				g_worker = null;
-
 				break;
 			case 'uncompressed_each':
 				var filename = e.data.filename;
@@ -1304,10 +1300,10 @@ function startWorker() {
 
 				g_titles[index] = filename;
 
-				makeThumbNail(filename, is_cached, function() {
-					var loadingProgress = $('#loadingProgress')[0];
-					loadingProgress.innerHTML = 'Loading ' + ((index / (g_image_count - 1)) * 100.0).toFixed(1) + '% ...';
+				var loadingProgress = $('#loadingProgress')[0];
+				loadingProgress.innerHTML = 'Loading ' + ((index / (g_image_count - 1)) * 100.0).toFixed(1) + '% ...';
 
+				makeThumbNail(filename, is_cached, function() {
 					if (index === 0) {
 						loadCurrentPage(function() {
 							$(window).trigger('resize');
@@ -1317,12 +1313,7 @@ function startWorker() {
 					}
 
 					if (is_last) {
-						// Stop the worker
-						var message = {
-							action: 'stop'
-						};
-						g_worker.postMessage(message);
-						g_worker = null;
+						stopWorker();
 
 						$('#loadingProgress').hide();
 						$('#loadingProgress')[0].innerHTML = '';
@@ -1346,6 +1337,14 @@ function startWorker() {
 	};
 	g_worker.postMessage(message);
 
+}
+
+function stopWorker() {
+	var message = {
+		action: 'stop'
+	};
+	g_worker.postMessage(message);
+	g_worker = null;
 }
 
 function makeThumbNail(filename, is_cached, cb) {

--- a/main.js
+++ b/main.js
@@ -331,12 +331,11 @@ function loadComic() {
 
 	// Get the file's info
 	var file = file_input[0].files[0];
-	var blob = file.slice();
-	var filename = file.name.toLowerCase();
+	var filename = file.name;
 	var filesize = file.size;
 	var filetype = file.type;
 
-	onLoaded(blob, filename, filesize, filetype);
+	onLoaded(file, filename, filesize, filetype);
 }
 
 function friendlyPageNumber() {
@@ -469,6 +468,7 @@ function clearComicData() {
 	g_are_thumbnails_loading = false;
 }
 
+// FIXME: Remove the size and type parameters, as they are not used
 function onLoaded(blob, filename, filesize, filetype) {
 	$('body')[0].style.backgroundColor = 'black';
 
@@ -501,17 +501,7 @@ function onLoaded(blob, filename, filesize, filetype) {
 		});
 	// If the file is not cached, uncompress it from the file
 	} else {
-		var reader = new FileReader();
-		reader.onload = function(evt) {
-			var array_buffer = reader.result;
-			var message = {
-				action: 'uncompress',
-				filename: filename,
-				array_buffer: array_buffer
-			};
-			g_worker.postMessage(message, [array_buffer]);
-		};
-		reader.readAsArrayBuffer(blob);
+		g_worker.postMessage(blob);
 	}
 }
 

--- a/main.js
+++ b/main.js
@@ -1368,6 +1368,7 @@ function makeThumbNail(filename, is_cached, cb) {
 				var ctx = canvas.getContext('2d');
 				ctx.drawImage(img, 0, 0, img.width, img.height, 0, 0, width, height);
 				canvas.toBlob(function(small_blob) {
+					img.src = '';
 					setCachedFile('small', filename, small_blob, function(is_success) {
 						if (! is_success) {
 							onStorageFull(filename);


### PR DESCRIPTION
This should use less memory.
* The web workers are recycled, when done. Which frees all the worker's memory.
* More data conversions happen in the workers.
* Thumb nails are loaded from the DB, only when needed. Not all loaded and stored for later.
* Pages are loaded from the DB, only when needed. Not all loaded and stored for later.
